### PR TITLE
change registrant index

### DIFF
--- a/IOTRegistryStore/IOTRegistryStore.pb.go
+++ b/IOTRegistryStore/IOTRegistryStore.pb.go
@@ -26,8 +26,8 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 type Identities struct {
-	RegistrantName string `protobuf:"bytes,1,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
-	Pubkey         []byte `protobuf:"bytes,3,opt,name=Pubkey,proto3" json:"Pubkey,omitempty"`
+	RegistrantName   string `protobuf:"bytes,1,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
+	RegistrantPubkey []byte `protobuf:"bytes,3,opt,name=RegistrantPubkey,proto3" json:"RegistrantPubkey,omitempty"`
 }
 
 func (m *Identities) Reset()         { *m = Identities{} }
@@ -43,10 +43,10 @@ func (m *Alias) String() string { return proto.CompactTextString(m) }
 func (*Alias) ProtoMessage()    {}
 
 type Things struct {
-	Alias          []string `protobuf:"bytes,1,rep,name=Alias" json:"Alias,omitempty"`
-	RegistrantName string   `protobuf:"bytes,2,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
-	Data           string   `protobuf:"bytes,3,opt,name=Data" json:"Data,omitempty"`
-	SpecName       string   `protobuf:"bytes,4,opt,name=SpecName" json:"SpecName,omitempty"`
+	Alias            []string `protobuf:"bytes,1,rep,name=Alias" json:"Alias,omitempty"`
+	RegistrantPubkey string   `protobuf:"bytes,2,opt,name=RegistrantPubkey" json:"RegistrantPubkey,omitempty"`
+	Data             string   `protobuf:"bytes,3,opt,name=Data" json:"Data,omitempty"`
+	SpecName         string   `protobuf:"bytes,4,opt,name=SpecName" json:"SpecName,omitempty"`
 }
 
 func (m *Things) Reset()         { *m = Things{} }
@@ -54,8 +54,8 @@ func (m *Things) String() string { return proto.CompactTextString(m) }
 func (*Things) ProtoMessage()    {}
 
 type Spec struct {
-	RegistrantName string `protobuf:"bytes,2,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
-	Data           string `protobuf:"bytes,1,opt,name=Data" json:"Data,omitempty"`
+	RegistrantPubkey string `protobuf:"bytes,2,opt,name=RegistrantPubkey" json:"RegistrantPubkey,omitempty"`
+	Data             string `protobuf:"bytes,1,opt,name=Data" json:"Data,omitempty"`
 }
 
 func (m *Spec) Reset()         { *m = Spec{} }

--- a/IOTRegistryStore/IOTRegistryStore.proto
+++ b/IOTRegistryStore/IOTRegistryStore.proto
@@ -10,18 +10,18 @@ syntax ="proto3";
 
 message Identities{
   string RegistrantName =1;
-  bytes Pubkey = 3;
+  bytes RegistrantPubkey = 3;
 }
 message Alias{
   bytes Nonce =1;
 }
 message Things{
   repeated string Alias =1;
-  string RegistrantName =2;
+  string RegistrantPubkey =2;
   string Data =3;
   string SpecName =4;
 }
 message Spec{
-	string RegistrantName =2;
+	string RegistrantPubkey =2;
 	string Data =1;
 }

--- a/IOTRegistryTX/IOTRegistry.pb.go
+++ b/IOTRegistryTX/IOTRegistry.pb.go
@@ -25,12 +25,12 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 type RegisterThingTX struct {
-	Nonce          []byte   `protobuf:"bytes,1,opt,name=Nonce,proto3" json:"Nonce,omitempty"`
-	Identities     []string `protobuf:"bytes,2,rep,name=Identities" json:"Identities,omitempty"`
-	RegistrantName string   `protobuf:"bytes,3,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
-	Signature      []byte   `protobuf:"bytes,4,opt,name=Signature,proto3" json:"Signature,omitempty"`
-	Data           string   `protobuf:"bytes,5,opt,name=Data" json:"Data,omitempty"`
-	Spec           string   `protobuf:"bytes,6,opt,name=Spec" json:"Spec,omitempty"`
+	Nonce            []byte   `protobuf:"bytes,1,opt,name=Nonce,proto3" json:"Nonce,omitempty"`
+	Identities       []string `protobuf:"bytes,2,rep,name=Identities" json:"Identities,omitempty"`
+	RegistrantPubkey string   `protobuf:"bytes,3,opt,name=RegistrantPubkey" json:"RegistrantPubkey,omitempty"`
+	Signature        []byte   `protobuf:"bytes,4,opt,name=Signature,proto3" json:"Signature,omitempty"`
+	Data             string   `protobuf:"bytes,5,opt,name=Data" json:"Data,omitempty"`
+	Spec             string   `protobuf:"bytes,6,opt,name=Spec" json:"Spec,omitempty"`
 }
 
 func (m *RegisterThingTX) Reset()         { *m = RegisterThingTX{} }
@@ -38,10 +38,10 @@ func (m *RegisterThingTX) String() string { return proto.CompactTextString(m) }
 func (*RegisterThingTX) ProtoMessage()    {}
 
 type CreateRegistrantTX struct {
-	RegistrantName string `protobuf:"bytes,1,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
-	PubKey         []byte `protobuf:"bytes,2,opt,name=PubKey,proto3" json:"PubKey,omitempty"`
-	Signature      []byte `protobuf:"bytes,4,opt,name=Signature,proto3" json:"Signature,omitempty"`
-	Data           string `protobuf:"bytes,3,opt,name=Data" json:"Data,omitempty"`
+	RegistrantName   string `protobuf:"bytes,1,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
+	RegistrantPubkey []byte `protobuf:"bytes,2,opt,name=RegistrantPubkey,proto3" json:"RegistrantPubkey,omitempty"`
+	Signature        []byte `protobuf:"bytes,4,opt,name=Signature,proto3" json:"Signature,omitempty"`
+	Data             string `protobuf:"bytes,3,opt,name=Data" json:"Data,omitempty"`
 }
 
 func (m *CreateRegistrantTX) Reset()         { *m = CreateRegistrantTX{} }
@@ -49,10 +49,10 @@ func (m *CreateRegistrantTX) String() string { return proto.CompactTextString(m)
 func (*CreateRegistrantTX) ProtoMessage()    {}
 
 type RegisterSpecTX struct {
-	SpecName       string `protobuf:"bytes,1,opt,name=SpecName" json:"SpecName,omitempty"`
-	RegistrantName string `protobuf:"bytes,2,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
-	Signature      []byte `protobuf:"bytes,3,opt,name=Signature,proto3" json:"Signature,omitempty"`
-	Data           string `protobuf:"bytes,4,opt,name=Data" json:"Data,omitempty"`
+	SpecName         string `protobuf:"bytes,1,opt,name=SpecName" json:"SpecName,omitempty"`
+	RegistrantPubkey string `protobuf:"bytes,2,opt,name=RegistrantPubkey" json:"RegistrantPubkey,omitempty"`
+	Signature        []byte `protobuf:"bytes,3,opt,name=Signature,proto3" json:"Signature,omitempty"`
+	Data             string `protobuf:"bytes,4,opt,name=Data" json:"Data,omitempty"`
 }
 
 func (m *RegisterSpecTX) Reset()         { *m = RegisterSpecTX{} }

--- a/IOTRegistryTX/IOTRegistry.proto
+++ b/IOTRegistryTX/IOTRegistry.proto
@@ -4,7 +4,7 @@ syntax ="proto3";
 message RegisterThingTX {
     bytes Nonce =1;
     repeated string Identities =2;
-    string RegistrantName =3;
+    string RegistrantPubkey =3;
     bytes Signature =4;
     string Data =5;
     string Spec =6;
@@ -12,14 +12,14 @@ message RegisterThingTX {
 
 message CreateRegistrantTX{
     string RegistrantName =1;
-    bytes PubKey =2;
+    bytes RegistrantPubkey =2;
     bytes Signature =4;
     string Data =3;
 }
 
 message RegisterSpecTX{
 	string SpecName =1;
-	string RegistrantName =2;
+	string RegistrantPubkey =2;
 	bytes Signature =3;
     string Data =4;
 }


### PR DESCRIPTION
change registrant index from name to public key. So, instead of a registrant being stored on the ledger as RegistrantName:<name> it is now RegistrantPubkey:<pubkey>. Also updated thing and spec to reflect changed registrant index. Passes all tests