### PR TITLE
Standardize names

### DIFF
--- a/IOTRegistry.go
+++ b/IOTRegistry.go
@@ -133,7 +133,7 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 		}
 
 		//marshall into store type. Then put that variable into the state
-		store := IOTRegistryStore.Identities{}
+		store := IOTRegistryStore.Registrant{}
 		store.RegistrantName = registerNameArgs.RegistrantName
 		store.RegistrantPubkey = registerNameArgs.RegistrantPubkey
 		storeBytes, err := proto.Marshal(&store)
@@ -218,7 +218,7 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 		}
 
 		//retrieve state associated with owner name to get public key
-		ownerRegistration := IOTRegistryStore.Identities{}
+		ownerRegistration := IOTRegistryStore.Registrant{}
 		err = proto.Unmarshal(checkIDBytes, &ownerRegistration)
 		if err != nil {
 			fmt.Printf("Error unmarshalling RegistrantPubkey (%s) state (%v)", registerThingArgs.RegistrantPubkey, err.Error())
@@ -255,7 +255,7 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 			stub.PutState("Alias:"+identity, aliasStoreBytes)
 		}
 
-		store := IOTRegistryStore.Things{}
+		store := IOTRegistryStore.Thing{}
 		store.Alias = registerThingArgs.Identities
 		store.RegistrantPubkey = registerThingArgs.RegistrantPubkey
 		store.Data = registerThingArgs.Data
@@ -319,7 +319,7 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 		}
 
 		//retrieve state associated with owner name to get public key
-		ownerRegistration := IOTRegistryStore.Identities{}
+		ownerRegistration := IOTRegistryStore.Registrant{}
 		err = proto.Unmarshal(checkIDBytes, &ownerRegistration)
 		if err != nil {
 			return nil, err
@@ -385,7 +385,7 @@ func (t *IOTRegistry) Query(stub shim.ChaincodeStubInterface, function string, a
 			return nil, fmt.Errorf("No argument specified\n")
 		}
 
-		owner := IOTRegistryStore.Identities{}
+		owner := IOTRegistryStore.Registrant{}
 
 		RegistrantPubkey := args[0]
 		ownerBytes, err := stub.GetState("RegistrantPubkey:" + RegistrantPubkey)
@@ -413,7 +413,7 @@ func (t *IOTRegistry) Query(stub shim.ChaincodeStubInterface, function string, a
 		if len(args) != 1 {
 			return nil, fmt.Errorf("No argument specified\n")
 		}
-		thing := IOTRegistryStore.Things{}
+		thing := IOTRegistryStore.Thing{}
 		thingNonce := args[0]
 		thingBytes, err := stub.GetState("Thing:" + thingNonce)
 		if err != nil {

--- a/IOTRegistry.go
+++ b/IOTRegistry.go
@@ -256,7 +256,7 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 		}
 
 		store := IOTRegistryStore.Thing{}
-		store.Alias = registerThingArgs.Identities
+		store.Aliases = registerThingArgs.Identities
 		store.RegistrantPubkey = registerThingArgs.RegistrantPubkey
 		store.Data = registerThingArgs.Data
 		store.SpecName = registerThingArgs.Spec

--- a/IOTRegistry.go
+++ b/IOTRegistry.go
@@ -138,8 +138,8 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 		store.RegistrantPubkey = registerNameArgs.RegistrantPubkey
 		storeBytes, err := proto.Marshal(&store)
 		if err != nil {
-			fmt.Printf("Error marshalling variable of type IOTRegistryStore.Identities{}: (%v)\n", err.Error())
-			return nil, fmt.Errorf("Error marshalling variable of type IOTRegistryStore.Identities{}: (%v)\n", err.Error())
+			fmt.Printf("Error marshalling variable of type IOTRegistryStore.Aliases{}: (%v)\n", err.Error())
+			return nil, fmt.Errorf("Error marshalling variable of type IOTRegistryStore.Aliases{}: (%v)\n", err.Error())
 		}
 
 		err = stub.PutState("RegistrantPubkey:"+hex.EncodeToString(registerNameArgs.RegistrantPubkey), storeBytes)
@@ -150,8 +150,8 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 	/*
 		registerThing does, essentially, two things.
 		1.	puts a "Thing:<Nonce>" state to the ledger, indexed by the nonce.
-		|		-a thing contains a string slice of identities, a RegistrantPubkey, an arbitrary string of data, and the name of a specification.
-		2.	for each element of the Identities string slice, puts an "Alias:<identity>" state to the ledger, indexed by identity.
+		|		-a thing contains a string slice of Aliases, a RegistrantPubkey, an arbitrary string of data, and the name of a specification.
+		2.	for each element of the Aliases string slice, puts an "Alias:<identity>" state to the ledger, indexed by identity.
 		|		-an Alias contains a nonce, which can be used to access its parent "thing"
 		TX struct: 		RegisterThingTX
 		Store structs: 	Things, Alias
@@ -202,15 +202,15 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 			return nil, fmt.Errorf("RegistrantPubkey (%s) is not registered\n", registerThingArgs.RegistrantPubkey)
 		}
 
-		//check if any identities exist
-		//we're checking if any identities are registered as RegistrantPubkeys but not if they are registered as aliases
-		for _, identity := range registerThingArgs.Identities {
+		//check if any Aliases exist
+		//we're checking if any Aliases are registered as RegistrantPubkeys but not if they are registered as aliases
+		for _, identity := range registerThingArgs.Aliases {
 			aliasCheckBytes, err := stub.GetState("RegistrantPubkey:" + identity)
 			if err != nil {
 				fmt.Printf("Could not get identity: (%s) State\n", identity)
 				return nil, fmt.Errorf("Could not get identity: (%s) State\n", identity)
 			}
-			//throw error if any of the identities already exist
+			//throw error if any of the Aliases already exist
 			if len(aliasCheckBytes) != 0 {
 				fmt.Printf("RegistrantPubkey: (%s) is already in registry\n", identity)
 				return nil, fmt.Errorf("RegistrantPubkey: (%s) is already in registry\n", identity)
@@ -231,7 +231,7 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 
 		//TODO review later
 		message := registerThingArgs.RegistrantPubkey
-		for _, identity := range registerThingArgs.Identities {
+		for _, identity := range registerThingArgs.Aliases {
 			message += ":" + identity
 		}
 		message += ":" + registerThingArgs.Data
@@ -242,7 +242,7 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 			return nil, fmt.Errorf("Error verifying signature (%s)", ownerSig)
 		}
 
-		for _, identity := range registerThingArgs.Identities {
+		for _, identity := range registerThingArgs.Aliases {
 
 			alias := IOTRegistryStore.Alias{}
 			alias.Nonce = registerThingArgs.Nonce
@@ -256,7 +256,7 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 		}
 
 		store := IOTRegistryStore.Thing{}
-		store.Aliases = registerThingArgs.Identities
+		store.Aliases = registerThingArgs.Aliases
 		store.RegistrantPubkey = registerThingArgs.RegistrantPubkey
 		store.Data = registerThingArgs.Data
 		store.SpecName = registerThingArgs.Spec
@@ -354,11 +354,11 @@ func (t *IOTRegistry) Invoke(stub shim.ChaincodeStubInterface, function string, 
 
 /* declares, initializes, and marshalls struct containing owner information to JSON */
 func RegistrantToJSON(RegistrantName string, pubKey []byte) ([]byte, error) {
-	type JSONIdentities struct {
+	type JSONAliases struct {
 		RegistrantName string
 		Pubkey         string
 	}
-	jsonOwner := JSONIdentities{}
+	jsonOwner := JSONAliases{}
 	jsonOwner.RegistrantName = RegistrantName
 	jsonOwner.Pubkey = hex.EncodeToString(pubKey)
 

--- a/IOTRegistryStore/IOTRegistryStore.pb.go
+++ b/IOTRegistryStore/IOTRegistryStore.pb.go
@@ -43,7 +43,7 @@ func (m *Alias) String() string { return proto.CompactTextString(m) }
 func (*Alias) ProtoMessage()    {}
 
 type Thing struct {
-	Alias            []string `protobuf:"bytes,1,rep,name=Alias" json:"Alias,omitempty"`
+	Aliases          []string `protobuf:"bytes,1,rep,name=Aliases" json:"Aliases,omitempty"`
 	RegistrantPubkey string   `protobuf:"bytes,2,opt,name=RegistrantPubkey" json:"RegistrantPubkey,omitempty"`
 	Data             string   `protobuf:"bytes,3,opt,name=Data" json:"Data,omitempty"`
 	SpecName         string   `protobuf:"bytes,4,opt,name=SpecName" json:"SpecName,omitempty"`

--- a/IOTRegistryStore/IOTRegistryStore.pb.go
+++ b/IOTRegistryStore/IOTRegistryStore.pb.go
@@ -9,9 +9,9 @@ It is generated from these files:
 	IOTRegistryStore.proto
 
 It has these top-level messages:
-	Identities
+	Registrant
 	Alias
-	Things
+	Thing
 	Spec
 */
 package IOTRegistryStore
@@ -25,14 +25,14 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-type Identities struct {
+type Registrant struct {
 	RegistrantName   string `protobuf:"bytes,1,opt,name=RegistrantName" json:"RegistrantName,omitempty"`
 	RegistrantPubkey []byte `protobuf:"bytes,3,opt,name=RegistrantPubkey,proto3" json:"RegistrantPubkey,omitempty"`
 }
 
-func (m *Identities) Reset()         { *m = Identities{} }
-func (m *Identities) String() string { return proto.CompactTextString(m) }
-func (*Identities) ProtoMessage()    {}
+func (m *Registrant) Reset()         { *m = Registrant{} }
+func (m *Registrant) String() string { return proto.CompactTextString(m) }
+func (*Registrant) ProtoMessage()    {}
 
 type Alias struct {
 	Nonce []byte `protobuf:"bytes,1,opt,name=Nonce,proto3" json:"Nonce,omitempty"`
@@ -42,16 +42,16 @@ func (m *Alias) Reset()         { *m = Alias{} }
 func (m *Alias) String() string { return proto.CompactTextString(m) }
 func (*Alias) ProtoMessage()    {}
 
-type Things struct {
+type Thing struct {
 	Alias            []string `protobuf:"bytes,1,rep,name=Alias" json:"Alias,omitempty"`
 	RegistrantPubkey string   `protobuf:"bytes,2,opt,name=RegistrantPubkey" json:"RegistrantPubkey,omitempty"`
 	Data             string   `protobuf:"bytes,3,opt,name=Data" json:"Data,omitempty"`
 	SpecName         string   `protobuf:"bytes,4,opt,name=SpecName" json:"SpecName,omitempty"`
 }
 
-func (m *Things) Reset()         { *m = Things{} }
-func (m *Things) String() string { return proto.CompactTextString(m) }
-func (*Things) ProtoMessage()    {}
+func (m *Thing) Reset()         { *m = Thing{} }
+func (m *Thing) String() string { return proto.CompactTextString(m) }
+func (*Thing) ProtoMessage()    {}
 
 type Spec struct {
 	RegistrantPubkey string `protobuf:"bytes,2,opt,name=RegistrantPubkey" json:"RegistrantPubkey,omitempty"`

--- a/IOTRegistryStore/IOTRegistryStore.proto
+++ b/IOTRegistryStore/IOTRegistryStore.proto
@@ -18,11 +18,12 @@ message Alias{
 }
 
 message Thing{
-  repeated string Alias =1;
+  repeated string Aliases =1;
   string RegistrantPubkey =2;
   string Data =3;
   string SpecName =4;
 }
+
 message Spec{
 	string RegistrantPubkey =2;
 	string Data =1;

--- a/IOTRegistryStore/IOTRegistryStore.proto
+++ b/IOTRegistryStore/IOTRegistryStore.proto
@@ -8,14 +8,16 @@
 
 syntax ="proto3";
 
-message Identities{
+message Registrant {
   string RegistrantName =1;
   bytes RegistrantPubkey = 3;
 }
+
 message Alias{
   bytes Nonce =1;
 }
-message Things{
+
+message Thing{
   repeated string Alias =1;
   string RegistrantPubkey =2;
   string Data =3;

--- a/IOTRegistryTX/IOTRegistry.pb.go
+++ b/IOTRegistryTX/IOTRegistry.pb.go
@@ -26,7 +26,7 @@ var _ = math.Inf
 
 type RegisterThingTX struct {
 	Nonce            []byte   `protobuf:"bytes,1,opt,name=Nonce,proto3" json:"Nonce,omitempty"`
-	Identities       []string `protobuf:"bytes,2,rep,name=Identities" json:"Identities,omitempty"`
+	Aliases          []string `protobuf:"bytes,2,rep,name=Aliases" json:"Aliases,omitempty"`
 	RegistrantPubkey string   `protobuf:"bytes,3,opt,name=RegistrantPubkey" json:"RegistrantPubkey,omitempty"`
 	Signature        []byte   `protobuf:"bytes,4,opt,name=Signature,proto3" json:"Signature,omitempty"`
 	Data             string   `protobuf:"bytes,5,opt,name=Data" json:"Data,omitempty"`

--- a/IOTRegistryTX/IOTRegistry.proto
+++ b/IOTRegistryTX/IOTRegistry.proto
@@ -3,7 +3,7 @@ syntax ="proto3";
 
 message RegisterThingTX {
     bytes Nonce =1;
-    repeated string Identities =2;
+    repeated string Aliases =2;
     string RegistrantPubkey =3;
     bytes Signature =4;
     string Data =5;

--- a/IOTRegistry_test.go
+++ b/IOTRegistry_test.go
@@ -332,12 +332,12 @@ func checkQuery(t *testing.T, stub *shim.MockStub, function string, index string
 			return fmt.Errorf("\nPubkey got       (%s)\nPubkey expected: (%s)\n", jsonMap["Pubkey"], expected.pubKeyString)
 		}
 	} else if function == "thing" {
-		aliases := make([]string, len(jsonMap["Alias"].([]interface{})))
-		for i, element := range jsonMap["Alias"].([]interface{}) {
+		aliases := make([]string, len(jsonMap["Aliases"].([]interface{})))
+		for i, element := range jsonMap["Aliases"].([]interface{}) {
 			aliases[i] = element.(string)
 		}
 		if !(reflect.DeepEqual(aliases, expected.identities)) {
-			return fmt.Errorf("\nAlias got       (%x)\nAlias expected: (%x)\n", jsonMap["Alias"], expected.identities)
+			return fmt.Errorf("\nAlias got       (%x)\nAlias expected: (%x)\n", jsonMap["Aliases"], expected.identities)
 		}
 		if jsonMap["RegistrantPubkey"] != expected.pubKeyString {
 			return fmt.Errorf("\nRegistrantPubkey got       (%s)\nRegistrantPubkey expected: (%s)\n", jsonMap["RegistrantPubkey"], expected.pubKeyString)


### PR DESCRIPTION
Four changes made to standardize naming conventions across protobuf definitions:

In IOTRegistryStore:
1. Identities -> Registrant
2. Things -> Thing
3.  Under Thing, repeated string Alias -> repeated string Aliases

In IOTRegistryTX:

4. Under RegisterThingTX, repeated string Identities -> repeated string Aliases

These changes were made to eliminate potentially confusing usage of the term identities v. aliases, as well as updating the store to reflect the decision to use Registrant instead of Identity or Owner.